### PR TITLE
Fix example of splicing reader conditional

### DIFF
--- a/cheatsheet/clojuredocs/cheatsheet-embeddable-for-clojure.org.html
+++ b/cheatsheet/clojuredocs/cheatsheet-embeddable-for-clojure.org.html
@@ -3378,7 +3378,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/clojuredocs/cheatsheet-no-tooltips-no-cdocs-summary.html
+++ b/cheatsheet/clojuredocs/cheatsheet-no-tooltips-no-cdocs-summary.html
@@ -907,7 +907,7 @@ tr.even {
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/clojuredocs/cheatsheet-tiptip-cdocs-summary.html
+++ b/cheatsheet/clojuredocs/cheatsheet-tiptip-cdocs-summary.html
@@ -5006,7 +5006,7 @@ with-redefs-fn, set!, var-set, var-get, with-local-vars</pre>">var</a> <code><va
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/clojuredocs/cheatsheet-tiptip-no-cdocs-summary.html
+++ b/cheatsheet/clojuredocs/cheatsheet-tiptip-no-cdocs-summary.html
@@ -3528,7 +3528,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/clojuredocs/cheatsheet-use-title-attribute-cdocs-summary.html
+++ b/cheatsheet/clojuredocs/cheatsheet-use-title-attribute-cdocs-summary.html
@@ -5006,7 +5006,7 @@ with-redefs-fn, set!, var-set, var-get, with-local-vars">var</a> <code><var>x</v
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/clojuredocs/cheatsheet-use-title-attribute-no-cdocs-summary.html
+++ b/cheatsheet/clojuredocs/cheatsheet-use-title-attribute-no-cdocs-summary.html
@@ -3528,7 +3528,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-embeddable-for-clojure.org.html
+++ b/cheatsheet/grimoire/cheatsheet-embeddable-for-clojure.org.html
@@ -3378,7 +3378,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-embeddable.html
+++ b/cheatsheet/grimoire/cheatsheet-embeddable.html
@@ -757,7 +757,7 @@ document.write('<style type="text/css">code {\n	font-family: monospace;\n}\n\n.p
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-no-tooltips-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-no-tooltips-cdocs-summary.html
@@ -907,7 +907,7 @@ tr.even {
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-no-tooltips-no-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-no-tooltips-no-cdocs-summary.html
@@ -907,7 +907,7 @@ tr.even {
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-tiptip-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-tiptip-cdocs-summary.html
@@ -5006,7 +5006,7 @@ with-redefs-fn, set!, var-set, var-get, with-local-vars</pre>">var</a> <code><va
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-tiptip-no-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-tiptip-no-cdocs-summary.html
@@ -3528,7 +3528,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-use-title-attribute-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-use-title-attribute-cdocs-summary.html
@@ -5006,7 +5006,7 @@ with-redefs-fn, set!, var-set, var-get, with-local-vars">var</a> <code><var>x</v
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>

--- a/cheatsheet/grimoire/cheatsheet-use-title-attribute-no-cdocs-summary.html
+++ b/cheatsheet/grimoire/cheatsheet-use-title-attribute-no-cdocs-summary.html
@@ -3528,7 +3528,7 @@ itself (not its value) is returned. The reader macro #'x expands to (var x).
               </tr>
               <tr class="odd">
                 <td><code>#?@</code></td>
-                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
+                <td><code>(1.7) <a href="http://clojure.org/reference/reader#_reader_conditionals">Splicing reader conditional</a>: <code>[1 #?@(:clj [x y] :cljs [w z]) 3]</code> reads as <code>[1 x y 3]</code> on JVM, <code>[1 w z 3]</code> in ClojureScript, <code>[1 3]</code> elsewhere.</code></td>
               </tr>
               <tr class="even">
                 <td><code>#foo</code></td>


### PR DESCRIPTION
It looks as if the `@` was accidentally omitted from the usage example.